### PR TITLE
wraps verifier.verify in try catch to protect against synchronous errors

### DIFF
--- a/lib/dkim.js
+++ b/lib/dkim.js
@@ -355,7 +355,15 @@ function verifyMessageSignature(headers, body, sig, rec) {
     '-----BEGIN PUBLIC KEY-----\n'+
     rec.p.replace(/(.{1,64})/g, '$1\n')+
     '-----END PUBLIC KEY-----\n';
-  if (!verifier.verify(pubKeyPEM, sig.b, 'base64')) {
+
+  var verified = false;
+  try {
+    verified = verifier.verify(pubKeyPEM, sig.b, 'base64');
+  } catch(e) {
+    // dont.evenworryabout.it
+  }
+
+  if (!verified) {
     return {ok: false, msg: "Signature could not be verified"};
   }
   return {ok: true};


### PR DESCRIPTION
Apparently crypto.createVerify().verify() can throw a synchronous error. This PR will catch the error and return `ok: false` with an error message.