### PR TITLE
adds result to failing recursive dkim signature evaluation

### DIFF
--- a/lib/dkim.js
+++ b/lib/dkim.js
@@ -434,7 +434,7 @@ function DKIMVerify(email, callback, sigs) {
       // set top-level error detail
       sigs.result = false;
       sigs.issue_desc = sig.msg;
-      sigs.sigs.push({h:sigHeader.headers})
+      sigs.sigs.push({h:sigHeader.headers, result: false});
       return callback(null, sigs);
     }
 


### PR DESCRIPTION
fixes the dreaded `null` result on signature objects for messages with more than one signature with at least one failing.