### PR TITLE
FAD-4779 fixes lost error messages

### DIFF
--- a/lib/dkim.js
+++ b/lib/dkim.js
@@ -464,7 +464,7 @@ function DKIMVerify(email, callback, sigs) {
         // The other DNS errors are operational in nature;
         sigs.result = sig.result = false;
         sigs.issue_desc = sig.issue_desc = 'There was an error while fetching the DNS record';
-        sigs.issue_desc_detail = sig.issue_desc_detail = [sig.s, sig.d, err.code, err.message].join(' ');
+        sigs.issue_desc_detail = sig.issue_desc_detail = [sig.s, sig.d, err.code, err.message].join(' | ');
 
         return callback(null, sigs); // just return the sigs or else we will breaks promisification
       }

--- a/lib/dkim.js
+++ b/lib/dkim.js
@@ -463,8 +463,9 @@ function DKIMVerify(email, callback, sigs) {
 
         // The other DNS errors are operational in nature;
         sigs.result = sig.result = false;
-        sigs.issue_desc = sig.issue_desc = err;
-        return callback(err, sigs);
+        sigs.issue_desc = sig.issue_desc = err.message;
+
+        return callback(null, sigs); // returning the error AND the sigs breaks promisification... should do callback(null, sigs)
       }
 
       rec = parseDKIMRecord(rawRec);
@@ -563,6 +564,7 @@ function moreSignatures(email) {
  */
 function keyFromDNS(selector, domain, callback) {
   var fqdn = selector +'._domainkey.'+ domain;
+
   dns.resolveTxt(fqdn, function(err, res) {
     if (err) {
       callback(err);

--- a/lib/dkim.js
+++ b/lib/dkim.js
@@ -463,9 +463,10 @@ function DKIMVerify(email, callback, sigs) {
 
         // The other DNS errors are operational in nature;
         sigs.result = sig.result = false;
-        sigs.issue_desc = sig.issue_desc = err.message;
+        sigs.issue_desc = sig.issue_desc = 'There was an error while fetching the DNS record';
+        sigs.issue_desc_detail = sig.issue_desc_detail = [err.code, err.message].join(': ');
 
-        return callback(null, sigs); // returning the error AND the sigs breaks promisification... should do callback(null, sigs)
+        return callback(null, sigs); // just return the sigs or else we will breaks promisification
       }
 
       rec = parseDKIMRecord(rawRec);

--- a/lib/dkim.js
+++ b/lib/dkim.js
@@ -464,7 +464,7 @@ function DKIMVerify(email, callback, sigs) {
         // The other DNS errors are operational in nature;
         sigs.result = sig.result = false;
         sigs.issue_desc = sig.issue_desc = 'There was an error while fetching the DNS record';
-        sigs.issue_desc_detail = sig.issue_desc_detail = [err.code, err.message].join(': ');
+        sigs.issue_desc_detail = sig.issue_desc_detail = [sig.s, sig.d, err.code, err.message].join(' ');
 
         return callback(null, sigs); // just return the sigs or else we will breaks promisification
       }

--- a/test/dkim.js
+++ b/test/dkim.js
@@ -357,6 +357,24 @@ exports["Sign+verify tests"] = {
             test.done();
         });
     },
+    "Record DNS error": function(test) {
+      var mail = testMsg();
+      var dkimField = signMsg(mail, "node.ee", "dkim");
+      dkim.keyFromDNS = function(s, d, callback) {
+        var err = new Error();
+        err.code = 'WHOOPS';
+        err.message = 'uh-oh';
+        callback(err);
+      };
+      dkim.DKIMVerify(dkimField + "\r\n" + mail, function(err, result) {
+        test.equal(err, null);
+        test.equal(result.result, false);
+        test.equal(result.issue_desc, 'There was an error while fetching the DNS record');
+        test.equal(result.issue_desc_detail, 'WHOOPS: uh-oh');
+        test.done();
+      });
+    },
+
     "Record malformed": function(test) {
         var mail = testMsg();
         var dkimField = signMsg(mail, "node.ee", "dkim");

--- a/test/dkim.js
+++ b/test/dkim.js
@@ -370,7 +370,7 @@ exports["Sign+verify tests"] = {
         test.equal(err, null);
         test.equal(result.result, false);
         test.equal(result.issue_desc, 'There was an error while fetching the DNS record');
-        test.equal(result.issue_desc_detail, 'dkim node.ee WHOOPS uh-oh');
+        test.equal(result.issue_desc_detail, 'dkim | node.ee | WHOOPS | uh-oh');
         test.done();
       });
     },

--- a/test/dkim.js
+++ b/test/dkim.js
@@ -370,7 +370,7 @@ exports["Sign+verify tests"] = {
         test.equal(err, null);
         test.equal(result.result, false);
         test.equal(result.issue_desc, 'There was an error while fetching the DNS record');
-        test.equal(result.issue_desc_detail, 'WHOOPS: uh-oh');
+        test.equal(result.issue_desc_detail, 'dkim node.ee WHOOPS uh-oh');
         test.done();
       });
     },


### PR DESCRIPTION
fixes dropped error messages in the dkim validator. Returns a formatted signature and not the `err` object in case of a random DNS error. 